### PR TITLE
Extra content is now updated on manage page when loading old content

### DIFF
--- a/frontend/src/pages/ManageContent.tsx
+++ b/frontend/src/pages/ManageContent.tsx
@@ -219,11 +219,13 @@ const ManageContent = () => {
           
           // Sets the extra content state
           if ("blog" in value.requestedData.extra_content) {
+            setExtraContentType(ContentType.Blog);
             setBlogData({
               action: ReducerAction.Set,
               newState: value.requestedData.extra_content["blog"]
             });
           } else if ("project" in value.requestedData.extra_content) {
+            setExtraContentType(ContentType.Project);
             setProjectData({
               action: ReducerAction.Set,
               newState: value.requestedData.extra_content["project"]


### PR DESCRIPTION
Fixed the bug where when when trying to update or delete content the old content that is loaded would not set the extra content. Content the extra content section should now update to match the content being loaded properly.