### PR TITLE
Added page reloading to project page

### DIFF
--- a/frontend/src/components/RequestHandling/ErrorDisplay.tsx
+++ b/frontend/src/components/RequestHandling/ErrorDisplay.tsx
@@ -3,22 +3,49 @@ import styled from "styled-components";
 
 /* -------------------------------------------------------------------------- */
 
+const ErrorDiv = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+`;
+
 const ErrorText = styled.p`
   text-align: center;
+`;
+
+const RetryButton = styled.button`
+  padding: 0.7rem 2.5rem;
+  display: block; 
+  background-color: ${props => props.theme.backgroundColour};
+  font-size: 1.6rem;
+  color: ${props => props.theme.textColour};
+  border: 0.3rem solid ${props => props.theme.lightTone};
+  &:hover {
+    border: 0.3rem solid ${props => props.theme.highlight};
+  }
 `;
 
 /* -------------------------------------------------------------------------- */
 
 interface ErrorDisplayProps {
-  errorString: String
+  errorString: String,
+  retryFunc?: () => void
 }
 
-const ErrorDisplay = ({errorString}: ErrorDisplayProps) => {
+const ErrorDisplay = ({errorString, retryFunc}: ErrorDisplayProps) => {
   // What to display when a request returns an error
   return(
-    <ErrorText>
-      {errorString}
-    </ErrorText>
+    <ErrorDiv>
+      <ErrorText>
+        {errorString}
+      </ErrorText>
+      {
+        retryFunc !== undefined &&
+        <RetryButton onClick={retryFunc}>
+          Retry
+        </RetryButton>
+      }
+    </ErrorDiv>
   )
 }
 

--- a/frontend/src/components/RequestHandling/LoadingErrorHandler.tsx
+++ b/frontend/src/components/RequestHandling/LoadingErrorHandler.tsx
@@ -12,6 +12,8 @@ interface stateEffect<T extends Function> {
   callCount?: number
 }
 
+//TODO document API for this element
+
 // Parameters to the component below
 // ____Element parameters are component function that will be returned when the specified state is active
 // ____Effect are side effect function to call when the specified state is active
@@ -19,8 +21,9 @@ interface LoadErrorHandleProps<T> {
   requestInfo: RequestState<T>
   successElement?: (data: {data: T}) => JSX.Element,
   successEffect?: stateEffect<(data: {data: T}) => void>,
-  errorElement?: (errorString: {errorString: string}) => JSX.Element,
+  errorElement?: (errorString: {errorString: string, retryFunc?: () => void}) => JSX.Element,
   errorEffect?: stateEffect<(errorString: {errorString: string}) => void>,
+  retryFunc?: () => void,
   loadingElement?: () => JSX.Element,
   loadingEffect?: stateEffect<() => void>,
   placeHolders?: boolean
@@ -104,11 +107,11 @@ const LoadErrorHandle = <T, >(handlingData: LoadErrorHandleProps<T>): JSX.Elemen
       // if now will return placeholder or nothing
       if (handlingData.errorElement !== undefined) {
         let ErrorElement = handlingData.errorElement;
-        return <ErrorElement errorString={handlingData.requestInfo.requestError} />;
+        return <ErrorElement errorString={handlingData.requestInfo.requestError} retryFunc={handlingData.retryFunc} />;
       }
 
       if (handlingData.placeHolders === undefined ||  handlingData.placeHolders === true) {
-        return <ErrorDisplay errorString={handlingData.requestInfo.requestError} />;
+        return <ErrorDisplay errorString={handlingData.requestInfo.requestError} retryFunc={handlingData.retryFunc} />;
       }
 
       return <></>;


### PR DESCRIPTION
When loading new projects from page changes or initial load if the request fails users will now be presented with a button to try and reload the current page of projects